### PR TITLE
Fixed J6uil.txt Requirement:

### DIFF
--- a/doc/J6uil.txt
+++ b/doc/J6uil.txt
@@ -30,6 +30,9 @@ Requirement:
 	cURL
 	http://curl.haxx.se/
 
+	webapi-vim
+	https://github.com/mattn/webapi-vim
+
 	vimproc
 	https://github.com/Shougo/vimproc
 


### PR DESCRIPTION
webapi-vim がなかったので追加しました。
