### PR TITLE
Avoid to use Vital.Web.HTTP.Python

### DIFF
--- a/autoload/J6uil/lingr.vim
+++ b/autoload/J6uil/lingr.vim
@@ -132,7 +132,7 @@ function! s:get(url, param)
         \ 'url'     : s:api_root . a:url,
         \ 'param'   : a:param,
         \ 'headers' : {},
-        \ 'client'  : 'curl',
+        \ 'client'  : ['curl', 'wget', 'python'],
         \ })
   return s:Web_JSON.decode(res.content)
 endfunction


### PR DESCRIPTION
Vital.Web.HTTP.Pythonにバグがあるようで、lingrから取ってくるメッセージの内容によっては、レスポンスを途中までしか持って来られずに、jsonデコードの際にエラーが発生します。
J6uil.vimは元々curlに依存しているため、Vital.Web.HTTP.Curlのみ使用するように修正しました。
