### PR TITLE
Support splitbelow and splitright

### DIFF
--- a/autoload/J6uil/buffer.vim
+++ b/autoload/J6uil/buffer.vim
@@ -35,7 +35,7 @@ function! J6uil#buffer#layout(rooms)
   silent! only
 
   " members
-  silent! vsplit J6uil_members
+  silent! leftabove vsplit J6uil_members
   setlocal noswapfile
   setlocal nolist
   setlocal nonu
@@ -44,7 +44,7 @@ function! J6uil#buffer#layout(rooms)
   setfiletype J6uil_members
 
   " rooms
-  silent! split  J6uil_rooms
+  silent! leftabove split  J6uil_rooms
   setlocal noswapfile
   setlocal nolist
   setlocal nonu


### PR DESCRIPTION
`set splitbelow splitright` かつ `let g:J6uil_multi_window = 1` の場合、レイアウトが壊れる問題を修正しました。

ref: http://vim-jp.org/vim-users-jp/2011/01/31/Hack-198.html
